### PR TITLE
fix(blobs): Fixes error when channel_values contain a null. #10

### DIFF
--- a/langgraph/checkpoint/mysql/utils.py
+++ b/langgraph/checkpoint/mysql/utils.py
@@ -8,9 +8,10 @@ MySQLBase64Blob = str
 
 
 def decode_base64_blob(base64_blob: MySQLBase64Blob) -> bytes:
+    if not base64_blob:
+        return None
     _, data = base64_blob.rsplit(":", 1)
     return base64.b64decode(data)
-
 
 class MySQLPendingWrite(NamedTuple):
     """


### PR DESCRIPTION
See issue #10. This is a blocking bug that prevents this module from being used.