### PR TITLE
fix(query): Fixes json_extract query when path has ':' in key. #9

### DIFF
--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -71,7 +71,7 @@ select
         from
         (
             select channel, json_unquote(
-                json_extract(checkpoint, concat('$.channel_versions.', channel))
+                json_extract(checkpoint, concat('$.channel_versions.', '"', channel, '"'))
             ) as version
             from json_table(
                 json_keys(checkpoint, '$.channel_versions'),


### PR DESCRIPTION
See issue #9. This is a blocking bug that prevents the module from being used.