### PR TITLE
Refactor base64 decoding null check.

### DIFF
--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -157,11 +157,15 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
     def _dump_checkpoint(self, checkpoint: Checkpoint) -> dict[str, Any]:
         return {**checkpoint, "pending_sends": []}
 
-    def _load_blobs(self, blob_values: list[tuple[str, str, Optional[bytes]]]) -> dict[str, Any]:
+    def _load_blobs(
+        self, blob_values: list[tuple[str, str, Optional[bytes]]]
+    ) -> dict[str, Any]:
         if not blob_values:
             return {}
         return {
-            k: self.serde.loads_typed((t, v)) for k, t, v in blob_values if t != "empty" and v
+            k: self.serde.loads_typed((t, v))
+            for k, t, v in blob_values
+            if t != "empty" and v
         }
 
     def _dump_blobs(

--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -143,7 +143,7 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
     def _load_checkpoint(
         self,
         checkpoint: dict[str, Any],
-        channel_values: list[tuple[str, str, bytes]],
+        channel_values: list[tuple[str, str, Optional[bytes]]],
         pending_sends: list[tuple[str, bytes]],
     ) -> Checkpoint:
         return {
@@ -157,11 +157,11 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
     def _dump_checkpoint(self, checkpoint: Checkpoint) -> dict[str, Any]:
         return {**checkpoint, "pending_sends": []}
 
-    def _load_blobs(self, blob_values: list[tuple[str, str, bytes]]) -> dict[str, Any]:
+    def _load_blobs(self, blob_values: list[tuple[str, str, Optional[bytes]]]) -> dict[str, Any]:
         if not blob_values:
             return {}
         return {
-            k: self.serde.loads_typed((t, v)) for k, t, v in blob_values if t != "empty"
+            k: self.serde.loads_typed((t, v)) for k, t, v in blob_values if t != "empty" and v
         }
 
     def _dump_blobs(


### PR DESCRIPTION
The base64 decoding function is used to deserialize channel values, pending writes, and pending sends. Even though pending writes and pending sends also have nullable blobs according to the DB schema, they seem to always hold non-null values.

The code and type hints in the _load_checkpoint method assume that pending write and pending sends are non-null, so we continue to do the same and only scope null handling to channel values.

We also add a test to catch this regression moving forward.

Builds off of https://github.com/tjni/langgraph-checkpoint-mysql/pull/11.