### PR TITLE
ci: turn off release attestations

### DIFF
--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -85,3 +85,5 @@ jobs:
           # This is *only for CI use* and is *extremely dangerous* otherwise!
           # https://github.com/pypa/gh-action-pypi-publish#tolerating-release-package-file-duplicates
           skip-existing: true
+          # Temp workaround since attestations are on by default as of gh-action-pypi-publish v1.11.0
+          attestations: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,8 @@ jobs:
           packages-dir: dist/
           verbose: true
           print-hash: true
+          # Temp workaround since attestations are on by default as of gh-action-pypi-publish v1.11.0
+          attestations: false
 
   mark-release:
     needs:


### PR DESCRIPTION
Apply https://github.com/langchain-ai/langgraph/pull/2252 to fix release pipeline.