### PR TITLE
fix(connection): Allows connecting via unix socket

### DIFF
--- a/langgraph/checkpoint/mysql/aio.py
+++ b/langgraph/checkpoint/mysql/aio.py
@@ -71,8 +71,16 @@ class AIOMySQLSaver(BaseMySQLSaver):
 
         Returns:
             AIOMySQLSaver: A new AIOMySQLSaver instance.
+
+        Example:
+            conn_string=mysql+aiomysql://user:password@localhost/db?unix_socket=/path/to/socket
         """
         parsed = urllib.parse.urlparse(conn_string)
+
+        # In order to provide additional params via the connection string,
+        # we convert the parsed.query to a dict so we can access the values.
+        # This is necessary when using a unix socket, for example.
+        params_as_dict = dict(urllib.parse.parse_qsl(parsed.query))
 
         async with aiomysql.connect(
             host=parsed.hostname or "localhost",
@@ -80,6 +88,7 @@ class AIOMySQLSaver(BaseMySQLSaver):
             password=parsed.password or "",
             db=parsed.path[1:],
             port=parsed.port or 3306,
+            unix_socket=params_as_dict.get("unix_socket"),
             autocommit=True,
         ) as conn:
             # This seems necessary until https://github.com/PyMySQL/PyMySQL/pull/1119


### PR DESCRIPTION
Unfortunately the base connection string parser does not take into consideration the need to connect via unix_socket, which is often what we may want to do when running an api and db in separate docker containers.

The connection string that I was trying to use was something like `mysql+aiomysql://user:password@localhost/db?query=unix_socket=/path/to/socket`. This is what I'm using for SQLAlchemy and it works just fine, but after looking at their parser it's because they do a bunch of special formatting to make sure that they capture additional params that might be used for the connection.

This change allows us to pass additional params in a vlid URI format using the query string params. We simply grab the params, if any, and convert them to a dict which then allows them to be used as needed. I've only added `unix_socket` because that's the issue that I was running in to, but we could easily use this to grab other connection values.

Let me know your thoughts on this, and thanks for taking this project on for the community :)

Closes #18 