### PR TITLE
Add and fix pregel tests for langgraph 0.2.58.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -373,17 +373,17 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langgraph"
-version = "0.2.56"
+version = "0.2.58"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = "<4.0,>=3.9.0"
 files = [
-    {file = "langgraph-0.2.56-py3-none-any.whl", hash = "sha256:ad8a4b772e34dc0137e890bb6ced596a39a1e684af66250c1e7c8150dbe90e9c"},
-    {file = "langgraph-0.2.56.tar.gz", hash = "sha256:af10b1ffd10d52fd4072a73f154b8c2513c0b22e5bd5d20f4567dfeecab98d1e"},
+    {file = "langgraph-0.2.58-py3-none-any.whl", hash = "sha256:24e3ab580e5406120d59cdc735b2019aa3d6f0c8d7fee1c3a517b4ecd95e3a1c"},
+    {file = "langgraph-0.2.58.tar.gz", hash = "sha256:a2ef9c40d13ef8973797eefe8832802593d24391cf8f81d0e108d0c336fbd4e6"},
 ]
 
 [package.dependencies]
-langchain-core = ">=0.2.43,<0.3.0 || >0.3.0,<0.3.1 || >0.3.1,<0.3.2 || >0.3.2,<0.3.3 || >0.3.3,<0.3.4 || >0.3.4,<0.3.5 || >0.3.5,<0.3.6 || >0.3.6,<0.3.7 || >0.3.7,<0.3.8 || >0.3.8,<0.3.9 || >0.3.9,<0.3.10 || >0.3.10,<0.3.11 || >0.3.11,<0.3.12 || >0.3.12,<0.3.13 || >0.3.13,<0.3.14 || >0.3.14,<0.4.0"
+langchain-core = ">=0.2.43,<0.3.0 || >0.3.0,<0.3.1 || >0.3.1,<0.3.2 || >0.3.2,<0.3.3 || >0.3.3,<0.3.4 || >0.3.4,<0.3.5 || >0.3.5,<0.3.6 || >0.3.6,<0.3.7 || >0.3.7,<0.3.8 || >0.3.8,<0.3.9 || >0.3.9,<0.3.10 || >0.3.10,<0.3.11 || >0.3.11,<0.3.12 || >0.3.12,<0.3.13 || >0.3.13,<0.3.14 || >0.3.14,<0.3.15 || >0.3.15,<0.3.16 || >0.3.16,<0.3.17 || >0.3.17,<0.3.18 || >0.3.18,<0.3.19 || >0.3.19,<0.3.20 || >0.3.20,<0.3.21 || >0.3.21,<0.3.22 || >0.3.22,<0.4.0"
 langgraph-checkpoint = ">=2.0.4,<3.0.0"
 langgraph-sdk = ">=0.1.42,<0.2.0"
 
@@ -1258,4 +1258,4 @@ pymysql = ["pymysql"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.0,<4.0"
-content-hash = "fb3add19a0b72dddeffa1b83b1a695408792604c3d60f295a573e66c8fc4d029"
+content-hash = "fb3004bc30022cec8a9c277f662ff7a4e755f75940d620d2e754a344b4dc1344"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ mypy = "^1.10.0"
 pymysql = "^1.1.1"
 aiomysql = "^0.2.0"
 types-PyMySQL = "^1.1.0"
-langgraph = "0.2.56"
+langgraph = "0.2.58"
 syrupy = "^4.0.2"
 pytest-repeat = "^0.9.3"
 pytest-xdist = {extras = ["psutil"], version = "^3.6.1"}


### PR DESCRIPTION
Applying https://github.com/langchain-ai/langgraph/pull/2378, https://github.com/langchain-ai/langgraph/pull/2661, https://github.com/langchain-ai/langgraph/pull/2682, https://github.com/langchain-ai/langgraph/pull/2683, https://github.com/langchain-ai/langgraph/pull/2693, and https://github.com/langchain-ai/langgraph/pull/2695.