### PR TITLE
Countermeasure for "Out of sort memory" occurring

### DIFF
--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -61,6 +61,9 @@ MIGRATIONS = [
     CREATE INDEX checkpoints_thread_id_idx ON checkpoints (thread_id);
     """,
     """
+    CREATE INDEX checkpoints_checkpoint_id_idx ON checkpoints (checkpoint_id);
+    """,
+    """
     CREATE INDEX checkpoint_blobs_thread_id_idx ON checkpoint_blobs (thread_id);
     """,
     """


### PR DESCRIPTION
Countermeasure for "Out of sort memory" occurring when the number of records increases under the same thread ID.
Add an index to the checkpoint_id in the checkpoints table.

Fixes tjni/langgraph-checkpoint-mysql#34