### PR TITLE
Fix OperationalError: Unknown column 'checkpoints.thread_id' in on clause

### DIFF
--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -137,10 +137,10 @@ select
             ) as channels
         ) as channel_versions
         inner join checkpoint_blobs bl
-            on bl.thread_id = checkpoints.thread_id
-            and bl.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
-            and bl.channel = channel_versions.channel
+            on bl.channel = channel_versions.channel
             and bl.version = channel_versions.version
+        where bl.thread_id = checkpoints.thread_id
+            and bl.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
     ) as channel_values,
     (
         select


### PR DESCRIPTION
This pull request addresses the issue of pymysql.err.OperationalError: (1054, "Unknown column 'checkpoints.thread_id' in 'on clause'") that occurs  under our situation:  MySQL 8.0   utf8mb4_general_ci .

Thank you for considering this change! 
