### PR TITLE
Add MariaDB support.

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,17 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mysql-version:
-          - "9"
-          - "8"
-          - "8.0.19"
+        database:
+          - db: "mysql"
+            version: "9"
+          - db: "mysql"
+            version: "8"
+          - db: "mysql"
+            version: "8.0.19"
+          - db: "mariadb"
+            version: "11"
+          - db: "mariadb"
+            version: "10"
         python-version:
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
 
-    name: "test python ${{ matrix.python-version }} | mysql ${{ matrix.mysql-version }}"
+    name: "test python ${{ matrix.python-version }} | ${{ matrix.database.db }} ${{ matrix.database.version }}"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}
@@ -36,12 +43,21 @@ jobs:
         run: |
           poetry install --with dev
 
-      - name: Run tests
+      - name: Run MySQL tests
+        if: ${{ matrix.database.db == 'mysql' }}
         shell: bash
         env:
-          MYSQL_VERSIONS: ${{ matrix.mysql-version }}
+          MYSQL_VERSIONS: ${{ matrix.database.version }}
         run: |
           make test
+
+      - name: Run MariaDB tests
+        if: ${{ matrix.database.db == 'mariadb' }}
+        shell: bash
+        env:
+          MARIADB_VERSIONS: ${{ matrix.database.version }}
+        run: |
+          make test-mariadb
 
       - name: Ensure the tests did not create any additional files
         shell: bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Implementation of LangGraph CheckpointSaver that uses MySQL.
 > The code in this repository tries to mimic the code in [langgraph-checkpoint-postgres](https://github.com/langchain-ai/langgraph/tree/main/libs/checkpoint-postgres) as much as possible to enable keeping in sync with the official checkpointer implementation.
 
 > [!NOTE]
-> In order to keep the queries close to the Postgres queries, we use features that require MySQL >= 8.0.19.
+> In order to keep the queries close to the Postgres queries, we use features that require MySQL >= 8.0.19 or MariaDB >= 10.7.1.
 
 ## Dependencies
 

--- a/langgraph/checkpoint/mysql/__init__.py
+++ b/langgraph/checkpoint/mysql/__init__.py
@@ -129,7 +129,7 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
             [CheckpointTuple(...), ...]
         """
         where, args = self._search_where(config, filter, before)
-        query = self.SELECT_SQL + where + " ORDER BY checkpoint_id DESC"
+        query = self._select_sql(where) + " ORDER BY checkpoint_id DESC"
         if limit:
             query += f" LIMIT {limit}"
         # if we change this to use .stream() we need to make sure to close the cursor
@@ -206,15 +206,25 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
         checkpoint_id = get_checkpoint_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
         if checkpoint_id:
-            args: tuple[Any, ...] = (thread_id, checkpoint_ns, checkpoint_id)
-            where = "WHERE thread_id = %s AND checkpoint_ns_hash = UNHEX(MD5(%s)) AND checkpoint_id = %s"
+            args = {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+            where = "WHERE thread_id = %(thread_id)s AND checkpoint_ns_hash = UNHEX(MD5(%(checkpoint_ns)s)) AND checkpoint_id = %(checkpoint_id)s"
         else:
-            args = (thread_id, checkpoint_ns)
-            where = "WHERE thread_id = %s AND checkpoint_ns_hash = UNHEX(MD5(%s)) ORDER BY checkpoint_id DESC LIMIT 1"
+            args = {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+            }
+            where = "WHERE thread_id = %(thread_id)s AND checkpoint_ns_hash = UNHEX(MD5(%(checkpoint_ns)s))"
 
+        query = self._select_sql(where)
+        if not checkpoint_id:
+            query += " ORDER BY checkpoint_id DESC LIMIT 1"
         with self._cursor() as cur:
             cur.execute(
-                self.SELECT_SQL + where,
+                query,
                 args,
             )
             values = cur.fetchall()
@@ -310,6 +320,7 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
                 self.UPSERT_CHECKPOINTS_SQL,
                 (
                     thread_id,
+                    checkpoint_ns,
                     checkpoint_ns,
                     checkpoint["id"],
                     checkpoint_id,

--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -13,6 +13,7 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
     get_checkpoint_id,
 )
+from langgraph.checkpoint.mysql.utils import mysql_mariadb_branch
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import TASKS, ChannelProtocol
 
@@ -96,30 +97,63 @@ MIGRATIONS = [
     """,
     # The following three migrations restore checkpoint_ns as part of the
     # primary key, but hashed to fit into the primary key size limit.
-    """
+    f"""
     ALTER TABLE checkpoints
-    ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,
+    {mysql_mariadb_branch(
+        "ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,",
+        "ADD COLUMN checkpoint_ns_hash BINARY(16),"
+    )}
     DROP PRIMARY KEY,
     ADD PRIMARY KEY (thread_id, checkpoint_ns_hash, checkpoint_id);
     """,
-    """
+    f"""
     ALTER TABLE checkpoint_blobs
-    ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,
+    {mysql_mariadb_branch(
+        "ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,",
+        "ADD COLUMN checkpoint_ns_hash BINARY(16),"
+    )}
     DROP PRIMARY KEY,
     ADD PRIMARY KEY (thread_id, checkpoint_ns_hash, channel, version);
     """,
-    """
+    f"""
     ALTER TABLE checkpoint_writes
-    ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,
+    {mysql_mariadb_branch(
+        "ADD COLUMN checkpoint_ns_hash BINARY(16) AS (UNHEX(MD5(checkpoint_ns))) STORED,",
+        "ADD COLUMN checkpoint_ns_hash BINARY(16),"
+    )}
     DROP PRIMARY KEY,
     ADD PRIMARY KEY (thread_id, checkpoint_ns_hash, checkpoint_id, task_id, idx);
     """,
     """
     ALTER TABLE checkpoint_writes ADD COLUMN task_path VARCHAR(2000) NOT NULL DEFAULT '';
     """,
+    # No longer use STORED generated columns, because MariaDB does not support
+    # using them in primary keys.
+    #
+    #  https://github.com/tjni/langgraph-checkpoint-mysql/issues/51
+    #
+    """
+    ALTER TABLE checkpoints MODIFY COLUMN checkpoint_ns_hash BINARY(16);
+    """,
+    """
+    ALTER TABLE checkpoint_blobs MODIFY COLUMN checkpoint_ns_hash BINARY(16);
+    """,
+    """
+    ALTER TABLE checkpoint_writes MODIFY COLUMN checkpoint_ns_hash BINARY(16);
+    """,
 ]
 
 SELECT_SQL = f"""
+with channel_versions as (
+    select thread_id, checkpoint_ns_hash, checkpoint_id, channel, json_unquote(
+        json_extract(checkpoint, concat('$.channel_versions.', '"', channel, '"'))
+    ) as version
+    from checkpoints, json_table(
+        json_keys(checkpoint, '$.channel_versions'),
+        '$[*]' columns (channel VARCHAR(150) CHARACTER SET utf8mb4 PATH '$')
+    ) as channels
+    {{WHERE}}
+)
 select
     thread_id,
     checkpoint,
@@ -128,71 +162,80 @@ select
     parent_checkpoint_id,
     metadata,
     (
-        select json_arrayagg(json_array(bl.channel, bl.type, bl.blob))
-        from
-        (
-            select channel, json_unquote(
-                json_extract(checkpoint, concat('$.channel_versions.', '"', channel, '"'))
-            ) as version
-            from json_table(
-                json_keys(checkpoint, '$.channel_versions'),
-                '$[*]' columns (channel VARCHAR(150) CHARACTER SET utf8mb4 PATH '$')
-            ) as channels
-        ) as channel_versions
+        select json_arrayagg(json_array(
+            bl.channel,
+            bl.type,
+            {mysql_mariadb_branch("bl.blob", "to_base64(bl.blob)")}
+        ))
+        from channel_versions
         inner join checkpoint_blobs bl
             on bl.channel = channel_versions.channel
             and bl.version = channel_versions.version
         where bl.thread_id = checkpoints.thread_id
             and bl.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
+            and channel_versions.thread_id = checkpoints.thread_id
+            and channel_versions.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
+            and channel_versions.checkpoint_id = checkpoints.checkpoint_id
     ) as channel_values,
     (
         select
-        json_arrayagg(json_array(cw.task_id, cw.channel, cw.type, cw.blob, cw.idx))
+        json_arrayagg(json_array(
+            cw.task_id,
+            cw.channel,
+            cw.type,
+            {mysql_mariadb_branch("cw.blob", "to_base64(cw.blob)")},
+            cw.idx
+        ))
         from checkpoint_writes cw
         where cw.thread_id = checkpoints.thread_id
             and cw.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
             and cw.checkpoint_id = checkpoints.checkpoint_id
     ) as pending_writes,
     (
-        select json_arrayagg(json_array(cw.task_path, cw.task_id, cw.type, cw.blob, cw.idx))
+        select json_arrayagg(json_array(
+            cw.task_path,
+            cw.task_id,
+            cw.type,
+            {mysql_mariadb_branch("cw.blob", "to_base64(cw.blob)")},
+            cw.idx
+        ))
         from checkpoint_writes cw
         where cw.thread_id = checkpoints.thread_id
             and cw.checkpoint_ns_hash = checkpoints.checkpoint_ns_hash
             and cw.checkpoint_id = checkpoints.parent_checkpoint_id
             and cw.channel = '{TASKS}'
     ) as pending_sends
-from checkpoints """
+from checkpoints {{WHERE}} """
 
 UPSERT_CHECKPOINT_BLOBS_SQL = """
-    INSERT IGNORE INTO checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, `blob`)
-    VALUES (%s, %s, %s, %s, %s, %s)
+    INSERT IGNORE INTO checkpoint_blobs (thread_id, checkpoint_ns, checkpoint_ns_hash, channel, version, type, `blob`)
+    VALUES (%s, %s, UNHEX(MD5(%s)), %s, %s, %s, %s)
 """
 
-UPSERT_CHECKPOINTS_SQL = """
-    INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
-    VALUES (%s, %s, %s, %s, %s, %s) AS new
+UPSERT_CHECKPOINTS_SQL = f"""
+    INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_ns_hash, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+    VALUES (%s, %s, UNHEX(MD5(%s)), %s, %s, %s, %s) {mysql_mariadb_branch("AS new", "")}
     ON DUPLICATE KEY UPDATE
-        checkpoint = new.checkpoint,
-        metadata = new.metadata;
+        checkpoint = {mysql_mariadb_branch("new.checkpoint", "VALUE(checkpoint)")},
+        metadata = {mysql_mariadb_branch("new.metadata", "VALUE(metadata)")}
 """
 
-UPSERT_CHECKPOINT_WRITES_SQL = """
-    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, `blob`)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) AS new
+UPSERT_CHECKPOINT_WRITES_SQL = f"""
+    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_ns_hash, checkpoint_id, task_id, task_path, idx, channel, type, `blob`)
+    VALUES (%s, %s, UNHEX(MD5(%s)), %s, %s, %s, %s, %s, %s, %s) {mysql_mariadb_branch("AS new", "")}
     ON DUPLICATE KEY UPDATE
-        channel = new.channel,
-        type = new.type,
-        `blob` = new.blob;
+        channel = {mysql_mariadb_branch("new.channel", "VALUE(channel)")},
+        type = {mysql_mariadb_branch("new.type", "VALUE(type)")},
+        `blob` = {mysql_mariadb_branch("new.blob", "VALUE(`blob`)")};
 """
 
 INSERT_CHECKPOINT_WRITES_SQL = """
-    INSERT IGNORE INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, `blob`)
-    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+    INSERT IGNORE INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_ns_hash, checkpoint_id, task_id, task_path, idx, channel, type, `blob`)
+    VALUES (%s, %s, UNHEX(MD5(%s)), %s, %s, %s, %s, %s, %s, %s)
 """
 
 
 class BaseMySQLSaver(BaseCheckpointSaver[str]):
-    SELECT_SQL = SELECT_SQL
     MIGRATIONS = MIGRATIONS
     UPSERT_CHECKPOINT_BLOBS_SQL = UPSERT_CHECKPOINT_BLOBS_SQL
     UPSERT_CHECKPOINTS_SQL = UPSERT_CHECKPOINTS_SQL
@@ -235,13 +278,14 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
         checkpoint_ns: str,
         values: dict[str, Any],
         versions: ChannelVersions,
-    ) -> list[tuple[str, str, str, str, str, Optional[bytes]]]:
+    ) -> list[tuple[str, str, str, str, str, str, Optional[bytes]]]:
         if not versions:
             return []
 
         return [
             (
                 thread_id,
+                checkpoint_ns,
                 checkpoint_ns,
                 k,
                 cast(str, ver),
@@ -278,10 +322,11 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
         task_id: str,
         task_path: str,
         writes: Sequence[tuple[str, Any]],
-    ) -> list[tuple[str, str, str, str, str, int, str, str, bytes]]:
+    ) -> list[tuple[str, str, str, str, str, str, int, str, str, bytes]]:
         return [
             (
                 thread_id,
+                checkpoint_ns,
                 checkpoint_ns,
                 checkpoint_id,
                 task_id,
@@ -317,41 +362,45 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
         config: Optional[RunnableConfig],
         filter: MetadataInput,
         before: Optional[RunnableConfig] = None,
-    ) -> tuple[str, list[Any]]:
+    ) -> tuple[str, dict[str, Any]]:
         """Return WHERE clause predicates for alist() given config, filter, before.
 
-        This method returns a tuple of a string and a tuple of values. The string
+        This method returns a tuple of a string and a dict of values. The string
         is the parametered WHERE clause predicate (including the WHERE keyword):
-        "WHERE column1 = $1 AND column2 IS $2". The list of values contains the
+        "WHERE column1 = $1 AND column2 IS $2". The dict of values contains the
         values for each of the corresponding parameters.
         """
         wheres = []
-        param_values = []
+        param_values = {}
 
         # construct predicate for config filter
         if config:
-            wheres.append("thread_id = %s ")
-            param_values.append(config["configurable"]["thread_id"])
+            wheres.append("thread_id = %(thread_id)s ")
+            param_values["thread_id"] = config["configurable"]["thread_id"]
             checkpoint_ns = config["configurable"].get("checkpoint_ns")
             if checkpoint_ns is not None:
-                wheres.append("checkpoint_ns_hash = UNHEX(MD5(%s))")
-                param_values.append(checkpoint_ns)
+                wheres.append("checkpoint_ns_hash = UNHEX(MD5(%(checkpoint_ns)s))")
+                param_values["checkpoint_ns"] = checkpoint_ns
 
             if checkpoint_id := get_checkpoint_id(config):
-                wheres.append("checkpoint_id = %s ")
-                param_values.append(checkpoint_id)
+                wheres.append("checkpoint_id = %(checkpoint_id)s ")
+                param_values["checkpoint_id"] = checkpoint_id
 
         # construct predicate for metadata filter
         if filter:
-            wheres.append("json_contains(metadata, %s) ")
-            param_values.append(json.dumps(filter))
+            wheres.append("json_contains(metadata, %(filter)s) ")
+            param_values["filter"] = json.dumps(filter)
 
         # construct predicate for `before`
         if before is not None:
-            wheres.append("checkpoint_id < %s ")
-            param_values.append(get_checkpoint_id(before))
+            wheres.append("checkpoint_id < %(before)s ")
+            param_values["before"] = get_checkpoint_id(before)
 
         return (
             "WHERE " + " AND ".join(wheres) if wheres else "",
             param_values,
         )
+
+    @staticmethod
+    def _select_sql(where: str) -> str:
+        return SELECT_SQL.replace("{WHERE}", where)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langgraph-checkpoint-mysql"
-version = "2.0.11"
+version = "2.0.12"
 description = "Library with a MySQL implementation of LangGraph checkpoint saver."
 authors = ["Theodore Ni <dev@ted.bio>"]
 license = "MIT"

--- a/tests/compose-mariadb.yml
+++ b/tests/compose-mariadb.yml
@@ -1,0 +1,24 @@
+services:
+  mariadb-test:
+    image: mariadb:${MARIADB_VERSION:-11}
+    ports:
+      - "5441:3306"
+    environment:
+      MARIADB_ROOT_PASSWORD: mysql
+      MARIADB_DATABASE: mysql
+      MARIADB_USER: mysql
+      MARIADB_PASSWORD: mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      timeout: 1s
+      retries: 5
+      interval: 60s
+      start_interval: 1s
+    configs:
+      - source: init.sql
+        target: /docker-entrypoint-initdb.d/init.sql
+configs:
+  init.sql:
+    content: |
+      GRANT ALL PRIVILEGES ON *.* TO 'mysql'@'%';


### PR DESCRIPTION
Adds support for MariaDB and closes https://github.com/tjni/langgraph-checkpoint-mysql/issues/51.

- It should support MariaDB >= 10.7 (which introduces JSON_EQUALS). (But since those old Docker images are not built with `healthcheck.sh`, I don't yet know how to set up the docker-compose file to test it.)
- It requires rewriting some queries.
    - MariaDB does not support using a STORED GENERATED column in the primary key. Replaced with a normal column and directly writing to it.
    - The checkpointer SELECT query used to rely on a correlated subquery in the FROM section of a SELECT, which is supported in MySQL >= 8.0.14 but not in MariaDB. To address this, I switched it to use a CTE.
    - MariaDB diverges from MySQL in JSON support:
        - Does not support `->>` operator. Replaced with `JSON_UNQUOTE(JSON_EXTRACT(%s))`.
        - Does not support `CAST(%s AS JSON)`. Replaced with `JSON_EXTRACT(%s, '$')`.
        - Does not support equals comparison for JSON. Replaced with `JSON_EQUALS(%s, %s)`.
        - Binary data in a JSON array is returned from MySQL in base64 prefixed with `base64:type251:`. In MariaDB, it just comes back as binary data, which is invalid JSON (and can be invalid UTF-8 too). We manually call the `TO_BASE64` function in MariaDB and adjust the deserialization to also handle data without the prefix.
    - MariaDB has different syntax for the `INSERT INTO ... ON DUPLICATE KEY UPDATE ...` query.

This passes the automated tests, but please report any issues you discover (both in MariaDB and in MySQL).