### PR TITLE
Support deserializing ("null", b"") properly.

### DIFF
--- a/langgraph/checkpoint/mysql/base.py
+++ b/langgraph/checkpoint/mysql/base.py
@@ -269,7 +269,7 @@ class BaseMySQLSaver(BaseCheckpointSaver[str]):
         return {
             k: self.serde.loads_typed((t, v))
             for k, t, v in blob_values
-            if t != "empty" and v
+            if t != "empty"
         }
 
     def _dump_blobs(

--- a/langgraph/checkpoint/mysql/utils.py
+++ b/langgraph/checkpoint/mysql/utils.py
@@ -69,7 +69,11 @@ def deserialize_channel_values(value: str) -> list[tuple[str, str, Optional[byte
     values = (MySQLChannelValue(*channel_value) for channel_value in json.loads(value))
 
     return [
-        (db.channel, db.type_, decode_base64_blob(db.blob) if db.blob else None)
+        (
+            db.channel,
+            db.type_,
+            decode_base64_blob(db.blob) if db.blob is not None else None,
+        )
         for db in values
     ]
 


### PR DESCRIPTION
There is a nasty bug caused by how I chose to refactor https://github.com/tjni/langgraph-checkpoint-mysql/pull/13 when using langgraph-checkpoint 2.0.24+.

In the implementation, we skip deserializing channel entries when the value of the entry is falsy, which includes empty bytes. In https://github.com/langchain-ai/langgraph/pull/4103, an optimization was put in place that serializes `None` as empty bytes.

This is just my mistake.